### PR TITLE
Allowing Multi-threaded LpVariable construction

### DIFF
--- a/pulp/pulp.py
+++ b/pulp/pulp.py
@@ -230,7 +230,10 @@ class LpElement(object):
         return LpAffineExpression(self) >= other
 
     def __eq__(self, other):
-        return LpAffineExpression(self) == other
+        if isinstance(other, LpElement) and self.hash == other.hash:
+            return not self.__ne__(other)
+        else:
+            return LpAffineExpression(self) == other
 
     def __ne__(self, other):
         if isinstance(other, LpVariable):


### PR DESCRIPTION
Avoid calling LpAffineExpression constructor from LpElement::eq() to avoid stack overflow on comparison operators in case of hash collision of LpElement items.

Note that I considered using a more advanced hash function for LpElement (using mmh3 for instance) possibly based on name attribute... but this is another improvement that I am not sure is relevant here.

The main advantage of this fix is that it allowed me to use pulp on several thread during LpVariable construction and avoid the crashed stemming from variables with same hash functions once all thread were merged.